### PR TITLE
[portability] use kind numbers from iso_fortran_env

### DIFF
--- a/tests/assert_test.f90
+++ b/tests/assert_test.f90
@@ -80,7 +80,8 @@ contains
     end subroutine
 
     subroutine assert_equal_double(val1, val2)
-        real(8), intent(in) :: val1, val2
+        use iso_fortran_env, Only:real64
+        real(real64), intent(in) :: val1, val2
 
         if (val1 == val2) then
             assert_nok = assert_nok + 1


### PR DESCRIPTION
Kind numbers such as 8 are not meaningful, better to use intrinsic module provided kind numbers.